### PR TITLE
fix the makefile file and fix the cpu occupancy problem in Win10 when using 'gnuplot -persist'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,46 +3,61 @@
 #
 
 SRCS_f90d1 = \
-ogpf.f90 \
+ogpf.f90
+
+SRCS_f90d2 = \
 demo.f90 
 
 OBJS_f90d1 = \
 ogpf.o \
+
+OBJS_f90d2 = \
 demo.o 
 
-SRC_DIR_f90d1 = 
-OBJS_DIR = obj/Debug/
-EXE_DIR = bin/Debug/
+SRC_DIR_f90d1 = \
+./src/
+
+SRC_DIR_f90d2 = \
+./example/
+
+
+OBJS_DIR = ./obj/Debug/
+EXE_DIR = ./bin/Debug/
 
 EXE = ogpf.exe
 FC = gfortran.exe
 LD = gfortran.exe
 IDIR = 
-CFLAGS = -Wall -g -std=f2008  -J$(OBJS_DIR) $(IDIR)
+CFLAGS = -Wall -std=f2008 -Wl, -J$(OBJS_DIR) $(IDIR)
 LFLAGS = 
 LIBS = 
 
-VPATH = $(SRC_DIR_f90d1):$(OBJS_DIR)
-OBJS = $(addprefix $(OBJS_DIR), $(OBJS_f90d1))
+VPATH = $(SRC_DIR_f90d1):$(OBJS_DIR):$(SRC_DIR_f90d2)
+OBJS = $(addprefix $(OBJS_DIR), $(OBJS_f90d1) $(OBJS_f90d2))
 
 all : $(EXE)
 
-$(EXE) : $(OBJS_f90d1)
+$(EXE) : $(OBJS_f90d1) $(OBJS_f90d2)
 	@mkdir -p $(EXE_DIR)
 	$(LD) -o $(EXE_DIR)$(EXE) $(OBJS) $(LFLAGS) $(LIBS)
 
 $(OBJS_f90d1):
 	@mkdir -p $(OBJS_DIR)
 	$(FC) $(CFLAGS) -c $(SRC_DIR_f90d1)$(@:.o=.f90) -o $(OBJS_DIR)$@
+	
+$(OBJS_f90d2):
+	@mkdir -p $(OBJS_DIR)
+	$(FC) $(CFLAGS) -c $(SRC_DIR_f90d2)$(@:.o=.f90) -o $(OBJS_DIR)$@
 
 clean :
 	rm -f $(OBJS_DIR)*.*
 	rm -f $(EXE_DIR)$(EXE)
 
-# Dependencies of files
-ogpf.o: \
-    ogpf.f90
+# Dependencies of files	
 demo.o: \
     demo.f90 \
     ogpf.o
+	
+ogpf.o: \
+    ogpf.f90
 

--- a/src/ogpf.f90
+++ b/src/ogpf.f90
@@ -2248,34 +2248,34 @@ contains
         this%hasfileopen = .false.        ! reset file open flag
         this%hasanimation = .false.
         ! Use shell command to run gnuplot
-		if (get_os_type() == 1) then
-			call execute_command_line ('wgnuplot -persist ' // this%txtfilename)  !   Now plot the results
-		else
-			call execute_command_line ('gnuplot -persist ' // this%txtfilename)  !   Now plot the results
-		end if
-	contains
-		integer function get_os_type() result(r)
-			!! Returns one of OS_WINDOWS, others
-			!! At first, the environment variable `OS` is checked, which is usually
-			!! found on Windows. 
-			!! Copy from fpm/fpm_environment: https://github.com/fortran-lang/fpm/blob/master/src/fpm_environment.f90
-			character(len=32) :: val
-			integer :: length, rc
-			
-			integer, parameter :: OS_OTHERS = 0
-			integer, parameter :: OS_WINDOWS = 1
-			
-			r = OS_OTHERS
-			! Check environment variable `OS`.
-			call get_environment_variable('OS', val, length, rc)
-			
-			if (rc == 0 .and. length > 0 .and. index(val, 'Windows_NT') > 0) then
-				r = OS_WINDOWS
-				return
-			end if
-			
-		end function
-		
+        if (get_os_type() == 1) then
+            call execute_command_line ('wgnuplot -persist ' // this%txtfilename)  !   Now plot the results
+        else
+            call execute_command_line ('gnuplot -persist ' // this%txtfilename)  !   Now plot the results
+        end if
+    contains
+        integer function get_os_type() result(r)
+            !! Returns one of OS_WINDOWS, others
+            !! At first, the environment variable `OS` is checked, which is usually
+            !! found on Windows. 
+            !! Copy from fpm/fpm_environment: https://github.com/fortran-lang/fpm/blob/master/src/fpm_environment.f90
+            character(len=32) :: val
+            integer :: length, rc
+            
+            integer, parameter :: OS_OTHERS = 0
+            integer, parameter :: OS_WINDOWS = 1
+            
+            r = OS_OTHERS
+            ! Check environment variable `OS`.
+            call get_environment_variable('OS', val, length, rc)
+            
+            if (rc == 0 .and. length > 0 .and. index(val, 'Windows_NT') > 0) then
+                r = OS_WINDOWS
+                return
+            end if
+            
+        end function
+        
     end subroutine finalize_plot
 
 

--- a/src/ogpf.f90
+++ b/src/ogpf.f90
@@ -2248,8 +2248,34 @@ contains
         this%hasfileopen = .false.        ! reset file open flag
         this%hasanimation = .false.
         ! Use shell command to run gnuplot
-        call execute_command_line ('gnuplot -persist ' // this%txtfilename)  !   Now plot the results
-
+		if (get_os_type() == 1) then
+			call execute_command_line ('wgnuplot -persist ' // this%txtfilename)  !   Now plot the results
+		else
+			call execute_command_line ('gnuplot -persist ' // this%txtfilename)  !   Now plot the results
+		end if
+	contains
+		integer function get_os_type() result(r)
+			!! Returns one of OS_WINDOWS, others
+			!! At first, the environment variable `OS` is checked, which is usually
+			!! found on Windows. 
+			!! Copy from fpm/fpm_environment: https://github.com/fortran-lang/fpm/blob/master/src/fpm_environment.f90
+			character(len=32) :: val
+			integer :: length, rc
+			
+			integer, parameter :: OS_OTHERS = 0
+			integer, parameter :: OS_WINDOWS = 1
+			
+			r = OS_OTHERS
+			! Check environment variable `OS`.
+			call get_environment_variable('OS', val, length, rc)
+			
+			if (rc == 0 .and. length > 0 .and. index(val, 'Windows_NT') > 0) then
+				r = OS_WINDOWS
+				return
+			end if
+			
+		end function
+		
     end subroutine finalize_plot
 
 


### PR DESCRIPTION
# 1. `gnuplot -persist` problem in Win10
I have pushed a issue (#15 ) about `gnuplot -persist` problem in Win10.
When running `gnuplot --persist *.gp`, the cpu is fully loaded (100%),
I think the `gnuplot --persist` command caused this problem.
![image](https://user-images.githubusercontent.com/32035096/116859983-6d2e6a00-ac33-11eb-9196-cb64c3eda121.png)

**The CPU occupancy is high**, which may be a **Windows-gnuplot's bug**. After testing, it is found that using the `wgnuplot -persist` command under Windows will not cause unexplained CPU occupancy problems.
![image](https://user-images.githubusercontent.com/32035096/116860146-b2eb3280-ac33-11eb-8ec6-8fcbe41b9811.png)

# 2. update makefile
I found that the folder structure of "ogpf" has changed, and the makefile is also invalid. I easily **updated** the makefile to make it available and valid.
