### PR TITLE
Added support for meson builder

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,10 @@
+project('Ogpf', 'fortran')
+
+libogpf = library('ogpf', 'src/ogpf.f90',
+  fortran_args: '-std=f2008')
+
+libogpf_dep = declare_dependency(
+  link_with: libogpf)
+
+executable('demo', 'example/demo.f90',
+  dependencies: libogpf_dep)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,8 @@
 project('Ogpf', 'fortran')
 
+gnuplot = find_program('gnuplot',
+  required: true)
+
 libogpf = library('ogpf', 'src/ogpf.f90',
   fortran_args: '-std=f2008')
 


### PR DESCRIPTION
Hello good sir, I went ahead and added support for the meson build system. This is a big deal because it allows for people to simply wrap this github repo to their projects as a subproject, and import the library. The meson build system allows for easy compilation of projects with mixed languages, which is generally my case.

Hope it helps!