### PR TITLE
(feature) Set each axis range individually.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,21 @@ These color palettes can be used with:
 * jet
 
 ## The ogpf library other features
-There are a plenety commands to customise the plots. This includes:
+There are plenty of commands to customise the plots. This includes:
 
 * Plot annotation (e.g. title, xlabel, ylabel, and zlabel)
 * Axes setting (e.g. xrange, yrange, zrange, and grid)
+
+```fortran
+call gp%axis([-1.0,+1.0])                     ! Sets xrange
+call gp%axis([-1.0,+1.0,-2.0,+2.0])           ! Sets both xrange and yrange
+call gp%axis([-1.0,+1.0,-2.0,+2.0,-3.0,+3.0]) ! Sets all axis at same time
+
+call gp%xlim([-1.0,+1.0]) ! Sets only the xrange
+call gp%ylim([-2.0,+3.0]) ! Sets only the yrange
+call gp%zlim([-3.0,+3.0]) ! Sets only the zrange
+```
+
 * Line and marker color and style
 * Gnuplot options (e.g. fonts, tics format, frame format,... )
 

--- a/example/demo.f90
+++ b/example/demo.f90
@@ -139,10 +139,11 @@ program demo
         print*, "Example 106: Multiplot layout in 3D"
         print*, "Example 107: Multiplot layout for 3D data"
         print*, "Example 108: Plot a 2D grid"
+        print*, "Example 109: Plot a 2D grid with random data, but use zlim to select a zrange"
 
         print*
         write (unit=*, fmt='(a)') "2D plots: select an example: 1 through 30"
-        write (unit=*, fmt='(a)') "3D plots: select an example: 101 through 108"
+        write (unit=*, fmt='(a)') "3D plots: select an example: 101 through 109"
         write (unit=*, fmt='(a)', advance='no') "enter 0 for exit:  "
         read*, i
 
@@ -226,6 +227,8 @@ program demo
                 call exmp107
            case(108)
                 call exmp108
+           case(109)
+                call exmp109
 
 
             case (0)
@@ -1477,6 +1480,41 @@ contains
     call gp%surf(x,y,z,lspec='w lp ps 2 pt 6 lc "#99aa33')
 
     end subroutine exmp108
+
+
+    !...............................................................................
+    !Example 109: Plot a 2D grid with random data, but use zlim to select a zrange
+    !...............................................................................
+    subroutine exmp109()
+        type(gpf):: gp
+        integer, parameter:: n=100
+
+        real(wp),    allocatable:: x(:,:)
+        real(wp),    allocatable:: y(:,:)
+        real(wp),    allocatable:: z(:,:)
+
+        ! create the xyz data
+        call meshgrid(x,y,linspace(-1.5_wp,1.5_wp,n))
+        allocate(z(n,n))
+        ! fills with random numbers
+        call random_number(z)
+        ! make them between -1.0_wp and 1.0_wp
+        z = z - 2.0_wp*z
+        ! create regions outsize such range
+        z = merge(-2.0_wp, z, x >= -.2_wp .and. x <= .2_wp)
+        z = merge(-2.0_wp, z, y >= -.2_wp .and. y <= .2_wp)
+
+        !plot the contour
+        call gp%title('Example 109: Zlim Example')
+        call gp%options('unset border') ! turn off border line (axes)
+        call gp%options('set view map')
+        ! Anything outside -1.0_wp and 1.0_wp will be cut off
+        call gp%zlim([-1.0_wp,1.0_wp])
+        call gp%options('set cbrange[-1.0:1.0]')
+        call gp%surf(x,y,z,palette='set1')
+
+    end subroutine exmp109
+
 
 
 end program demo

--- a/src/ogpf.f90
+++ b/src/ogpf.f90
@@ -278,6 +278,9 @@ module ogpf
         procedure, pass, public :: zlabel       => set_zlabel
         procedure, pass, public :: axis         => set_axis
         procedure, pass, public :: axis_sc      => set_secondary_axis
+        procedure, pass, public :: xlim         => set_xlim
+        procedure, pass, public :: ylim         => set_ylim
+        procedure, pass, public :: zlim         => set_zlim
         procedure, pass, public :: filename     => set_filename
         procedure, pass, public :: reset        => reset_to_defaults
         procedure, pass, public :: preset       => use_preset_configuration
@@ -366,6 +369,43 @@ contains
     end subroutine set_options
 
 
+    subroutine set_xlim(this,rng)
+        !..............................................................................
+        !Set the x axis limits in form of [xmin, xmax]
+        !..............................................................................
+
+        class(gpf):: this
+        real(wp), intent(in) :: rng(2)
+        this%hasxrange=.true.
+        this%xrange=rng
+
+    end subroutine
+
+
+    subroutine set_ylim(this,rng)
+        !..............................................................................
+        !Set the y axis limits in form of [ymin, ymax]
+        !..............................................................................
+
+        class(gpf):: this
+        real(wp), intent(in) :: rng(2)
+        this%hasyrange=.true.
+        this%yrange=rng
+
+    end subroutine
+    
+    
+    subroutine set_zlim(this,rng)
+        !..............................................................................
+        !Set the z axis limits in form of [zmin, zmax]
+        !..............................................................................
+
+        class(gpf):: this
+        real(wp), intent(in) :: rng(2)
+        this%haszrange=.true.
+        this%zrange=rng
+
+    end subroutine
 
 
     subroutine set_axis(this,rng)


### PR DESCRIPTION
Provides new functions `xlim`, `ylim` and `zlim`.
I haven't tested it (I actually did and it working as expected), but it should work out of the box since it follows how `set_axis` deals with it.
I also don't know if there is a equivalent `?lim` to that `set_secondary_axis` but I could work on that too if you point me in the right direction.

Sorry for delaying this PR.

Fixes #9 

PS: It seems the palette code could use some help too (I tried to load a custom one but it seems that is being ignored/overwritten).