### PR TITLE
fix command fmt for lplot3d()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@
 build*
 bin*
 
+/.vs
+/ifx/ifx_ogpf_vs22.fdz
+/ifx/ifx_ogpf_vs22.u2d
+
+ifx/.vs/
+
+ifx/x64/
+*.u2d
+*.fdz

--- a/src/ogpf.f90
+++ b/src/ogpf.f90
@@ -1397,9 +1397,9 @@ contains
 
          if ( present(lspec) ) then
              if (hastitle(lspec)) then
-                 pltstring='splot ' // datablock // ' ' // trim(lspec) // 'with lines'
+                 pltstring='splot ' // datablock // ' ' // trim(lspec) // ' with lines'
              else
-                 pltstring='splot ' // datablock // ' notitle '//trim(lspec) // 'with lines'
+                 pltstring='splot ' // datablock // ' notitle '// trim(lspec) // ' with lines'
              end if
          else
              pltstring='splot ' // datablock // ' notitle with lines'


### PR DESCRIPTION
Fix to address #49 when creating 3D line plots

A whitespace was required before the `with lines` parameter for `splot` command.